### PR TITLE
Implementation of node_api_tests::SpawnSync for macOS

### DIFF
--- a/unittests/NodeAPI/CMakeLists.txt
+++ b/unittests/NodeAPI/CMakeLists.txt
@@ -75,15 +75,27 @@ add_subdirectory(js)
 #   $<TARGET_FILE:libshared>
 #   $<TARGET_FILE_DIR:NodeApiTests>)
 
-add_executable(node_lite
-  child_process.cpp
-  child_process.h
-  node_lite.cpp
-  node_lite.h
-  node_lite_hermes.cpp
-  string_utils.cpp
-  string_utils.h
-)
+if(APPLE)
+  add_executable(node_lite
+    child_process_mac.cpp
+    child_process.h
+    node_lite.cpp
+    node_lite.h
+    node_lite_hermes.cpp
+    string_utils.cpp
+    string_utils.h
+  )
+else()
+  add_executable(node_lite
+    child_process.cpp
+    child_process.h
+    node_lite.cpp
+    node_lite.h
+    node_lite_hermes.cpp
+    string_utils.cpp
+    string_utils.h
+  )
+endif()
 
 target_link_libraries(node_lite
   hermesNodeApi
@@ -97,15 +109,27 @@ target_include_directories(node_lite
     ../../API/hermes_node_api/node_api
 )
 
-set(NodeApiTestsSources
-  child_process.cpp
-  child_process.h
-  string_utils.cpp
-  string_utils.h
-  test_main.cpp
-  test_main.h
-  test_basics.cpp
-)
+if(APPLE)
+  set(NodeApiTestsSources
+    child_process_mac.cpp
+    child_process.h
+    string_utils.cpp
+    string_utils.h
+    test_main.cpp
+    test_main.h
+    test_basics.cpp
+  )
+else()
+  set(NodeApiTestsSources
+    child_process.cpp
+    child_process.h
+    string_utils.cpp
+    string_utils.h
+    test_main.cpp
+    test_main.h
+    test_basics.cpp
+  )
+endif()
 
 add_hermes_unittest(nodeApiTests ${NodeApiTestsSources})
 

--- a/unittests/NodeAPI/CMakeLists.txt
+++ b/unittests/NodeAPI/CMakeLists.txt
@@ -76,26 +76,22 @@ add_subdirectory(js)
 #   $<TARGET_FILE_DIR:NodeApiTests>)
 
 if(APPLE)
-  add_executable(node_lite
-    child_process_mac.cpp
-    child_process.h
-    node_lite.cpp
-    node_lite.h
-    node_lite_hermes.cpp
-    string_utils.cpp
-    string_utils.h
-  )
+  set(CHILD_PROCESS_SRC child_process_mac.cpp)
 else()
-  add_executable(node_lite
-    child_process.cpp
-    child_process.h
-    node_lite.cpp
-    node_lite.h
-    node_lite_hermes.cpp
-    string_utils.cpp
-    string_utils.h
-  )
+  set(CHILD_PROCESS_SRC child_process.cpp)
 endif()
+
+set(NODE_LITE_SOURCES
+  ${CHILD_PROCESS_SRC}
+  child_process.h
+  node_lite.cpp
+  node_lite.h
+  node_lite_hermes.cpp
+  string_utils.cpp
+  string_utils.h
+)
+
+add_executable(node_lite ${NODE_LITE_SOURCES})
 
 target_link_libraries(node_lite
   hermesNodeApi
@@ -109,27 +105,15 @@ target_include_directories(node_lite
     ../../API/hermes_node_api/node_api
 )
 
-if(APPLE)
-  set(NodeApiTestsSources
-    child_process_mac.cpp
-    child_process.h
-    string_utils.cpp
-    string_utils.h
-    test_main.cpp
-    test_main.h
-    test_basics.cpp
-  )
-else()
-  set(NodeApiTestsSources
-    child_process.cpp
-    child_process.h
-    string_utils.cpp
-    string_utils.h
-    test_main.cpp
-    test_main.h
-    test_basics.cpp
-  )
-endif()
+set(NodeApiTestsSources
+  ${CHILD_PROCESS_SRC}
+  child_process.h
+  string_utils.cpp
+  string_utils.h
+  test_main.cpp
+  test_main.h
+  test_basics.cpp
+)
 
 add_hermes_unittest(nodeApiTests ${NodeApiTestsSources})
 

--- a/unittests/NodeAPI/child_process_mac.cpp
+++ b/unittests/NodeAPI/child_process_mac.cpp
@@ -1,0 +1,27 @@
+#include "child_process.h"
+
+#include <cassert>
+#include <cstdio>
+#include "string_utils.h"
+
+#ifndef VerifyElseExit
+#define VerifyElseExit(condition)                                              \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      ExitOnError(#condition);                                                 \
+    }                                                                          \
+  } while (false)
+#endif
+
+namespace node_api_tests {
+
+// Create a child process that uses the previously created pipes for STDIN and
+// STDOUT.
+ProcessResult SpawnSync(std::string_view command,
+                        std::vector<std::string> args) {
+  ProcessResult result{};
+
+  return result;
+}
+
+}  // namespace node_api_tests

--- a/unittests/NodeAPI/child_process_mac.cpp
+++ b/unittests/NodeAPI/child_process_mac.cpp
@@ -11,11 +11,27 @@
 #include <string>
 #include <vector>
 
+// Verify the condition.
+// - If true, resume execution.
+// - If false, print a message to stderr and exit the app with exit code 1.
 #ifndef VerifyElseExit
 #define VerifyElseExit(condition)                                              \
   do {                                                                         \
     if (!(condition)) {                                                        \
-      ExitOnError(#condition);                                                 \
+      ExitOnError(#condition, nullptr);                                        \
+    }                                                                          \
+  } while (false)
+#endif
+
+// Verify the condition.
+// - If true, resume execution.
+// - If false, destroy the passed `posix_spawn_file_actions_t* actions`, then
+// print a message to stderr and exit the app with exit code 1.
+#ifndef VerifyElseExitWithCleanup
+#define VerifyElseExitWithCleanup(condition, actions_ptr)                      \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      ExitOnError(#condition, actions_ptr);                                    \
     }                                                                          \
   } while (false)
 #endif
@@ -27,7 +43,7 @@ namespace node_api_tests {
 namespace {
 
 std::string ReadFromFd(int fd);
-void ExitOnError(const char* message);
+void ExitOnError(const char* message, posix_spawn_file_actions_t* actions);
 
 }  // namespace
 
@@ -43,15 +59,19 @@ ProcessResult SpawnSync(std::string_view command,
   posix_spawn_file_actions_t actions;
   VerifyElseExit(posix_spawn_file_actions_init(&actions) == 0);
 
-  VerifyElseExit(posix_spawn_file_actions_adddup2(
-                     &actions, stdout_pipe[1], STDOUT_FILENO) == 0);
-  VerifyElseExit(posix_spawn_file_actions_adddup2(
-                     &actions, stderr_pipe[1], STDERR_FILENO) == 0);
+  VerifyElseExitWithCleanup(posix_spawn_file_actions_adddup2(
+                                &actions, stdout_pipe[1], STDOUT_FILENO) == 0,
+                            &actions);
+  VerifyElseExitWithCleanup(posix_spawn_file_actions_adddup2(
+                                &actions, stderr_pipe[1], STDERR_FILENO) == 0,
+                            &actions);
 
-  VerifyElseExit(posix_spawn_file_actions_addclose(&actions, stdout_pipe[0]) ==
-                 0);
-  VerifyElseExit(posix_spawn_file_actions_addclose(&actions, stderr_pipe[0]) ==
-                 0);
+  VerifyElseExitWithCleanup(
+      posix_spawn_file_actions_addclose(&actions, stdout_pipe[0]) == 0,
+      &actions);
+  VerifyElseExitWithCleanup(
+      posix_spawn_file_actions_addclose(&actions, stderr_pipe[0]) == 0,
+      &actions);
 
   std::vector<char*> argv;
   argv.push_back(strdup(std::string(command).c_str()));
@@ -61,9 +81,9 @@ ProcessResult SpawnSync(std::string_view command,
   argv.push_back(nullptr);
 
   pid_t pid;
-  VerifyElseExit(
-      posix_spawnp(&pid, argv[0], &actions, nullptr, argv.data(), environ) ==
-      0);
+  VerifyElseExitWithCleanup(
+      posix_spawnp(&pid, argv[0], &actions, nullptr, argv.data(), environ) == 0,
+      &actions);
 
   posix_spawn_file_actions_destroy(&actions);
 
@@ -104,11 +124,15 @@ std::string ReadFromFd(int fd) {
 
 // Format a readable error message, print it to console, and exit from the
 // application.
-void ExitOnError(const char* message) {
+void ExitOnError(const char* message, posix_spawn_file_actions_t* actions) {
   int err = errno;
   const char* err_msg = strerror(err);
 
   fprintf(stderr, "%s failed with error %d: %s\n", message, err, err_msg);
+
+  if (actions != nullptr) {
+    posix_spawn_file_actions_destroy(actions);
+  }
 
   exit(1);
 }

--- a/unittests/NodeAPI/child_process_mac.cpp
+++ b/unittests/NodeAPI/child_process_mac.cpp
@@ -1,8 +1,15 @@
 #include "child_process.h"
 
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <cassert>
 #include <cstdio>
-#include "string_utils.h"
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #ifndef VerifyElseExit
 #define VerifyElseExit(condition)                                              \
@@ -13,15 +20,98 @@
   } while (false)
 #endif
 
+extern char** environ;
+
 namespace node_api_tests {
 
-// Create a child process that uses the previously created pipes for STDIN and
-// STDOUT.
+namespace {
+
+std::string ReadFromFd(int fd);
+void ExitOnError(const char* message);
+
+}  // namespace
+
 ProcessResult SpawnSync(std::string_view command,
                         std::vector<std::string> args) {
   ProcessResult result{};
 
+  // These int arrays each comprise two file descriptors: { readEnd, writeEnd }.
+  int stdout_pipe[2], stderr_pipe[2];
+  VerifyElseExit(pipe(stdout_pipe) == 0);
+  VerifyElseExit(pipe(stderr_pipe) == 0);
+
+  posix_spawn_file_actions_t actions;
+  VerifyElseExit(posix_spawn_file_actions_init(&actions) == 0);
+
+  VerifyElseExit(posix_spawn_file_actions_adddup2(
+                     &actions, stdout_pipe[1], STDOUT_FILENO) == 0);
+  VerifyElseExit(posix_spawn_file_actions_adddup2(
+                     &actions, stderr_pipe[1], STDERR_FILENO) == 0);
+
+  VerifyElseExit(posix_spawn_file_actions_addclose(&actions, stdout_pipe[0]) ==
+                 0);
+  VerifyElseExit(posix_spawn_file_actions_addclose(&actions, stderr_pipe[0]) ==
+                 0);
+
+  std::vector<char*> argv;
+  argv.push_back(strdup(std::string(command).c_str()));
+  for (const std::string& arg : args) {
+    argv.push_back(strdup(arg.c_str()));
+  }
+  argv.push_back(nullptr);
+
+  pid_t pid;
+  VerifyElseExit(
+      posix_spawnp(&pid, argv[0], &actions, nullptr, argv.data(), environ) ==
+      0);
+
+  posix_spawn_file_actions_destroy(&actions);
+
+  // Close the write ends of the pipes.
+  close(stdout_pipe[1]);
+  close(stderr_pipe[1]);
+
+  int wait_status;
+  VerifyElseExit(waitpid(pid, &wait_status, 0) == pid);
+
+  result.status = WIFEXITED(wait_status) ? WEXITSTATUS(wait_status) : 1;
+  result.std_output = ReadFromFd(stdout_pipe[0]);
+  result.std_error = ReadFromFd(stderr_pipe[0]);
+
+  // Close the read ends of the pipes.
+  close(stdout_pipe[0]);
+  close(stderr_pipe[0]);
+
+  for (char* arg : argv) {
+    free(arg);
+  }
+
   return result;
 }
 
+namespace {
+
+std::string ReadFromFd(int fd) {
+  std::string result;
+  constexpr size_t bufferSize = 4096;
+  char buffer[bufferSize];
+  ssize_t bytesRead;
+  while ((bytesRead = read(fd, buffer, bufferSize)) > 0) {
+    result.append(buffer, bytesRead);
+  }
+  return result;
+}
+
+// Format a readable error message, print it to console, and exit from the
+// application.
+void ExitOnError(const char* message) {
+  int err = errno;
+  const char* err_msg = strerror(err);
+
+  fprintf(stderr, "%s failed with error %d: %s\n", message, err, err_msg);
+
+  exit(1);
+}
+
+}  // namespace
 }  // namespace node_api_tests

--- a/unittests/NodeAPI/node_lite.cpp
+++ b/unittests/NodeAPI/node_lite.cpp
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #include "node_lite.h"
+#ifdef _WIN32
 #include <windows.h>
+#endif
 #include <algorithm>
 #include <array>
 #include <filesystem>
@@ -229,6 +231,7 @@ NodeApiRef NodeLiteRuntime::RunModuleScript(std::string const& code) noexcept {
 
 napi_value NodeLiteRuntime::GetModuleExports(
     napi_env env, std::string const& module_name) noexcept {
+#ifdef _WIN32
   napi_value result{};
 
   // Check if the module has already been initialized.
@@ -314,6 +317,7 @@ napi_value NodeLiteRuntime::GetModuleExports(
             ReadScriptText(script_dir_, script_file), script_path)));
   }
 
+#endif
   return NodeApi::GetUndefined(env);
 }
 

--- a/unittests/NodeAPI/node_lite.h
+++ b/unittests/NodeAPI/node_lite.h
@@ -103,22 +103,24 @@ class NodeLiteTaskRunner {
 
 class NodeLiteErrorHandler {
  public:
-  static void OnNodeApiFailed(napi_env env,
-                              napi_status error_code,
-                              char const* expr,
-                              const char* file,
-                              int32_t line) noexcept;
+  [[noreturn]] static void OnNodeApiFailed(napi_env env,
+                                           napi_status error_code,
+                                           char const* expr,
+                                           const char* file,
+                                           int32_t line) noexcept;
 
   static void OnAssertFailed(char const* expr,
                              char const* message,
                              const char* file,
                              int32_t line) noexcept;
 
-  static void ExitWithJSError(napi_env env, napi_value error) noexcept;
+  [[noreturn]] static void ExitWithJSError(napi_env env,
+                                           napi_value error) noexcept;
 
-  static void ExitWithJSAssertError(napi_env env, napi_value error) noexcept;
+  [[noreturn]] static void ExitWithJSAssertError(napi_env env,
+                                                 napi_value error) noexcept;
 
-  static void ExitWithMessage(
+  [[noreturn]] static void ExitWithMessage(
       const std::string& file,
       int line,
       const std::string& message,


### PR DESCRIPTION
I'm opening early as a draft so that anyone else can take over in case I run out of time to push this over the line.

POSIX APIs are a a new area to me, so I started off just by prompting an LLM to fill in an initial implementation, and then got to work comparing it line-by-line with other existing usages across GitHub to see if it was sane. I've checked the first half so far and it does appear to be consistent with various other usages of [posix_spawn](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/posix_spawn.2.html), so gives some confidence. I just want to check the second half next to be sure.

I also want to compare it against the [libuv](https://github.com/nodejs/node/blob/95b0f9d448832eeb75586c89fab0777a1a4b0610/deps/uv/src/unix/process.c#L528) and [Bun](https://github.com/oven-sh/bun/blob/879fdd7ef693618726aa9c2fdaa5124a2135596e/src/bun.js/api/bun/spawn.zig#L141) implementations to be sure nothing's been overlooked.

To be clear, the code compiles, but I've not tried running it yet. Will clearly need to give that a go, too.