### PR TITLE
Use `static_cast` of `vm::Runtime*`

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -2631,7 +2631,7 @@ void HermesRuntimeImpl::throwJSErrorWithMessage(Args &&...args) {
 void *HermesRuntimeImpl::createNodeApiEnv(int32_t apiVersion) {
 #ifndef HERMESVM_LEAN
   auto res = ::hermes::node_api::createModuleNodeApiEnvironment(
-      *this->getVMRuntimeUnsafe(), apiVersion);
+      *static_cast<vm::Runtime*>(this->getVMRuntimeUnsafe()), apiVersion);
   if (res.getStatus() == ::hermes::vm::ExecutionStatus::EXCEPTION) {
     throw std::runtime_error("Failed to create Node API environment");
   }


### PR DESCRIPTION
## Summary

As part of building for React Native 0.81.1 I experienced the following error:

```
[ios] ❌ /Users/kraen.hansen/Repositories/react-native-node-api/apps/test-app/ios/Pods/hermes-engine/API/hermes/hermes.cpp:2742:7: ISO C++ does not allow indirection on operand of type 'void *' [-Wvoid-ptr-dereference]
[ios]  2742 |       *this->getVMRuntimeUnsafe(), apiVersion);
[ios]       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[ios] ❌ /Users/kraen.hansen/Repositories/react-native-node-api/apps/test-app/ios/Pods/hermes-engine/API/hermes/hermes.cpp:2742:7: non-const lvalue reference to type 'vm::Runtime' cannot bind to a value of unrelated type 'void'
[ios]  2742 |       *this->getVMRuntimeUnsafe(), apiVersion);
[ios]       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Likely introduced by https://github.com/facebook/react-native/pull/46787 but it's uncertain to me why we haven't been hitting this before 🤔